### PR TITLE
Add compose setup using http-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # daily-mystery
+
+This repository contains a simple static site used for MVP and proof of concept purposes.
+
+## Development
+
+The project uses the [http-server](https://www.npmjs.com/package/http-server) package and includes Docker and docker-compose files so you can run everything in a container without installing Node on your host machine.
+
+To build and start the server:
+
+```bash
+docker-compose up --build
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "daily-mystery",
+  "version": "1.0.0",
+  "description": "Simple static site served with http-server",
+  "main": "index.js",
+  "scripts": {
+    "start": "http-server -p 8080 ."
+  },
+  "dependencies": {
+    "http-server": "^14.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- serve static content with the `http-server` npm package
- remove custom server code
- add a docker-compose file for easier local development
- document compose usage in README

## Testing
- `npm start` *(fails: `http-server: not found` - unable to fetch package)*
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884dbd57c28832fa9305c2e6cbebfef