### PR TITLE
Use volume for code and install deps at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM node:18-alpine
+
+# Set the working directory where the project will be mounted at runtime.
 WORKDIR /app
-COPY package*.json ./
-RUN npm install --production
-COPY . .
+
+# Expose the port used by the http-server package
 EXPOSE 8080
-CMD ["npm", "start"]
+
+# Install dependencies and start the server every time the container starts.
+# The project files will be mounted into /app via docker-compose.
+CMD ["sh", "-c", "npm install && npm start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,7 @@ version: '3.8'
 services:
   web:
     build: .
+    volumes:
+      - .:/app
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- mount project directory into container instead of copying files
- install npm packages every time the container starts

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884e379eb48832fbbfa8f4756d211d1